### PR TITLE
Updated deprecated idl commands for Ros Humble

### DIFF
--- a/vicon_receiver/CMakeLists.txt
+++ b/vicon_receiver/CMakeLists.txt
@@ -41,9 +41,8 @@ find_package("${rmw_implementation}" REQUIRED)
 get_rmw_typesupport(typesupport_impls "${rmw_implementation}" LANGUAGE "cpp")
 
 foreach(typesupport_impl ${typesupport_impls})
-  rosidl_target_interfaces(vicon_client
-    ${PROJECT_NAME} ${typesupport_impl}
-  )
+	rosidl_get_typesupport_target(typesupport_target ${PROJECT_NAME} ${typesupport_impl})
+	target_link_libraries(vicon_client ${typesupport_target})
 endforeach()
 
 install(TARGETS vicon_client DESTINATION lib/${PROJECT_NAME})

--- a/vicon_receiver/CMakeLists.txt
+++ b/vicon_receiver/CMakeLists.txt
@@ -25,9 +25,11 @@ find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread)
+find_package(std_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Position.msg"
+  DEPENDENCIES std_msgs
 )
 
 ament_export_dependencies(rosidl_default_runtime)

--- a/vicon_receiver/include/vicon_receiver/publisher.hpp
+++ b/vicon_receiver/include/vicon_receiver/publisher.hpp
@@ -22,6 +22,8 @@ class Publisher
 {
 private:
     rclcpp::Publisher<vicon_receiver::msg::Position>::SharedPtr position_publisher_;
+// Create pointer to the node itself.
+    rclcpp::Node* node_;
 
 public:
     bool is_ready = false;

--- a/vicon_receiver/launch/client.launch.py
+++ b/vicon_receiver/launch/client.launch.py
@@ -3,7 +3,7 @@ from launch_ros.actions import Node
 
 def generate_launch_description():
 
-    hostname = '192.168.1.1'
+    hostname = '192.168.1.3'
     buffer_size = 200
     topic_namespace = 'vicon'
 

--- a/vicon_receiver/msg/Position.msg
+++ b/vicon_receiver/msg/Position.msg
@@ -1,3 +1,4 @@
+std_msgs/Header header
 float32 x_trans 
 float32 y_trans
 float32 z_trans

--- a/vicon_receiver/package.xml
+++ b/vicon_receiver/package.xml
@@ -8,6 +8,8 @@
   <license>GNU General Public License v3</license>
   
   <member_of_group>rosidl_interface_packages</member_of_group>
+  <!-- Need this for header-->
+  <depend>std_msgs</depend>
 
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 

--- a/vicon_receiver/src/vicon_receiver/publisher.cpp
+++ b/vicon_receiver/src/vicon_receiver/publisher.cpp
@@ -1,6 +1,9 @@
 #include "vicon_receiver/publisher.hpp"
+#include "std_msgs/msg/header.hpp"
 
+// Constructor
 Publisher::Publisher(std::string topic_name, rclcpp::Node* node)
+    : node_(node) //I had no idea this syntax was a thing.
 {
     position_publisher_ = node->create_publisher<vicon_receiver::msg::Position>(topic_name, 10);
     is_ready = true;
@@ -9,6 +12,7 @@ Publisher::Publisher(std::string topic_name, rclcpp::Node* node)
 void Publisher::publish(PositionStruct p)
 {
     auto msg = std::make_shared<vicon_receiver::msg::Position>();
+    msg->header.stamp = node_->now();
     msg->x_trans = p.translation[0];
     msg->y_trans = p.translation[1];
     msg->z_trans = p.translation[2];


### PR DESCRIPTION
Replaced with "rosidl_target_interfaces()" with "rosidl_get_typesupport_target()" so that package compiles on ROS Humble.

Hopefully I made this pull request correctly.