### PR TITLE
Use `rosidl_get_typesupport_target()` and `target_link_libraries()` 

### DIFF
--- a/vicon_receiver/CMakeLists.txt
+++ b/vicon_receiver/CMakeLists.txt
@@ -41,9 +41,8 @@ find_package("${rmw_implementation}" REQUIRED)
 get_rmw_typesupport(typesupport_impls "${rmw_implementation}" LANGUAGE "cpp")
 
 foreach(typesupport_impl ${typesupport_impls})
-  rosidl_target_interfaces(vicon_client
-    ${PROJECT_NAME} ${typesupport_impl}
-  )
+  rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} ${typesupport_impl})
+  target_link_libraries(vicon_client "${cpp_typesupport_target}")
 endforeach()
 
 install(TARGETS vicon_client DESTINATION lib/${PROJECT_NAME})


### PR DESCRIPTION
Hi, the package currently seems to not work in Humble due to deprecated CMake calls.

This should fix the issue, it compiles successfully and the client node works as expected.

Kind regards!