### PR TITLE
Fixed bug where the default pose data would be published for occluded segments

### DIFF
--- a/vicon_receiver/src/communicator.cpp
+++ b/vicon_receiver/src/communicator.cpp
@@ -178,6 +178,11 @@ void Communicator::get_frame()
             Output_GetSegmentGlobalRotationQuaternion quat =
                 vicon_client.GetSegmentGlobalRotationQuaternion(subject_name, segment_name);
 
+            // Skip data publish if segment is occluded
+            if ( trans.Occluded || quat.Occluded ){
+                continue;
+            }
+            
             // Build a TF message for this segment
             geometry_msgs::msg::TransformStamped tf_msg;
 


### PR DESCRIPTION
It seems that the ros2-vicon-receiver was publishing default pose data,  i.e. position = [0 0 0] and quaternion = [0 0 0 0], when the segment became occluded or left the visibility region of the Vicon system. This may have caused issues for those using this receiver for control or data recording. Now, if the Vicon system detects that the segment is occluded, the receiver will skip publishing any pose data for the segment until it is visible. Best regards,